### PR TITLE
修复当user_id类型为string时的user_id大小计算错误问题:

### DIFF
--- a/src/Someline/Base/Models/BaseModel.php
+++ b/src/Someline/Base/Models/BaseModel.php
@@ -136,21 +136,6 @@ class BaseModel extends Model implements BaseModelEventsInterface
     }
 
     /**
-     * check the $user_id is valid.
-     *
-     * @param  int|string $user_id
-     * @return bool
-     */
-    protected function validUserId($user_id): bool
-    {
-        if ('int' === $this->keyType)
-            return $user_id > 0;
-
-        if ('string' === $this->keyType)
-            return strlen($user_id) > 0;
-    }
-
-    /**
      * Update the creation and update by users.
      *
      * @return void
@@ -312,6 +297,5 @@ class BaseModel extends Model implements BaseModelEventsInterface
     {
         return $this->updated_at;
     }
-
 
 }

--- a/src/Someline/Model/Traits/BaseModelEvents.php
+++ b/src/Someline/Model/Traits/BaseModelEvents.php
@@ -41,7 +41,7 @@ trait BaseModelEvents
         // auto set user id
         if ($this->autoUserId && empty($this->user_id)) {
             $user_id = $this->getAuthUserId();
-            if ($user_id > 0) {
+            if ($this->validUserId($user_id)) {
                 $this->user_id = $user_id;
             }
         }
@@ -94,4 +94,20 @@ trait BaseModelEvents
     public function onRestored()
     {
     }
+
+    /**
+     * check the $user_id is valid.
+     *
+     * @param  int|string $user_id
+     * @return bool
+     */
+    protected function validUserId($user_id): bool
+    {
+        if ('int' === $this->keyType)
+            return $user_id > 0;
+
+        if ('string' === $this->keyType)
+            return strlen($user_id) > 0;
+    }
+
 }


### PR DESCRIPTION
当 user_id 为 int 类型时,没有问题,但当为 string 类型(如uuid)时,就会有问题.
validUserId() 方法转移到BaseModelEvents.php中.