### PR TITLE
如果你想使用除了 email 以外的其他字段作为授权字段

### DIFF
--- a/src/Someline/Model/Foundation/User.php
+++ b/src/Someline/Model/Foundation/User.php
@@ -45,4 +45,34 @@ class User extends BaseModel implements BaseModelEventsInterface,
      */
     protected $primaryKey = 'user_id';
 
+    /**
+     * find users in any field, such as user e-mail or phone number.
+     *
+     * If you use Passport, you may need to rewrite the method.
+     *
+     * @param  string $username
+     * @return mixed
+     *
+     * @see    \Laravel\Passport\Bridge\UserRepository@getUserEntityByUserCredentials
+     * @see    https://segmentfault.com/a/1190000010499813#articleHeader0
+     * @see    https://blog.csdn.net/woqianduo/article/details/81782799
+     * @see    https://www.jianshu.com/p/12d06fc201af
+     */
+    public function findForPassport(string $username)
+    {
+        return $this->orWhere('email', $username)
+//            ->orWhere('mobile', $username)
+//            ->orWhere('more_field', $username)
+            ->first();
+    }
+
+    /**
+     * get which field is the password.
+     * @return string
+     */
+    public function getAuthPassword(): string
+    {
+        return $this->password;
+    }
+
 }

--- a/src/Someline/Model/Traits/BaseModelEvents.php
+++ b/src/Someline/Model/Traits/BaseModelEvents.php
@@ -38,6 +38,17 @@ trait BaseModelEvents
     public function onCreating()
     {
 
+        /*
+         * check whether the UUID primary key is used.
+         *
+         * if the $primaryKey value is string(single key), not an array(union key),
+         * and $incrementing is false, $keytype is string,
+         * automatically use UUID as $primaryKey if the $primaryKey is empty.
+         */
+        $keyIsEmpty = is_string($this->primaryKey) && empty(array_get($this->attributes, $this->primaryKey));
+        if ($keyIsEmpty && false === $this->incrementing && 'string' === $this->keyType)
+            $this->attributes[$this->primaryKey] = $this->uuid();
+
         // auto set user id
         if ($this->autoUserId && empty($this->user_id)) {
             $user_id = $this->getAuthUserId();
@@ -108,6 +119,20 @@ trait BaseModelEvents
 
         if ('string' === $this->keyType)
             return strlen($user_id) > 0;
+    }
+
+    /**
+     * generate a uuid string.
+     *
+     * @param  bool $use32bytes
+     * @return string the uuid string
+     */
+    protected function uuid(bool $use32bytes = false): string
+    {
+        if ($use32bytes)
+            return \Ramsey\Uuid\Uuid::uuid4()->getHex();
+
+        return \Ramsey\Uuid\Uuid::uuid4()->getNodeHex();
     }
 
 }


### PR DESCRIPTION
相信不少用户使用了passport后, 希望使用除了 email 以外的其他字段作为授权字段, 但是不知道怎么处理, 网络上的很多资料答非所问, 跟踪源码后, 发现在 Auth User 模型中添加一个方法, 即可解决这个问题.

另外, 如果已有的 Auth User表中没有 password 这个字段, 怎么办呢? 这里也该出了基于源码的解决方案.