### PR TITLE
Hotfix/fix error if create model with namespace

### DIFF
--- a/src/Someline/Model/Foundation/User.php
+++ b/src/Someline/Model/Foundation/User.php
@@ -45,4 +45,34 @@ class User extends BaseModel implements BaseModelEventsInterface,
      */
     protected $primaryKey = 'user_id';
 
+    /**
+     * find users in any field, such as user e-mail or phone number.
+     *
+     * If you use Passport, you may need to rewrite the method.
+     *
+     * @param  string $username
+     * @return mixed
+     *
+     * @see    \Laravel\Passport\Bridge\UserRepository@getUserEntityByUserCredentials
+     * @see    https://segmentfault.com/a/1190000010499813#articleHeader0
+     * @see    https://blog.csdn.net/woqianduo/article/details/81782799
+     * @see    https://www.jianshu.com/p/12d06fc201af
+     */
+    public function findForPassport(string $username)
+    {
+        return $this->orWhere('email', $username)
+//            ->orWhere('mobile', $username)
+//            ->orWhere('more_field', $username)
+            ->first();
+    }
+
+    /**
+     * get which field is the password.
+     * @return string
+     */
+    public function getAuthPassword(): string
+    {
+        return $this->password;
+    }
+
 }

--- a/src/Someline/Model/Traits/BaseModelEvents.php
+++ b/src/Someline/Model/Traits/BaseModelEvents.php
@@ -42,11 +42,11 @@ trait BaseModelEvents
          * check whether the UUID primary key is used.
          *
          * if the $primaryKey value is string(single key), not an array(union key),
-         * and $incrementing is false, $keytype is string,
+         * and $incrementing is false, $keyType is string,
          * automatically use UUID as $primaryKey if the $primaryKey is empty.
          */
         $keyIsEmpty = is_string($this->primaryKey) && empty(array_get($this->attributes, $this->primaryKey));
-        if ($keyIsEmpty && false === $this->incrementing && 'string' === $this->keyType)
+        if ($keyIsEmpty && (false === $this->incrementing) && ('string' === $this->keyType))
             $this->attributes[$this->primaryKey] = $this->uuid();
 
         // auto set user id

--- a/src/Someline/Model/Traits/BaseModelEvents.php
+++ b/src/Someline/Model/Traits/BaseModelEvents.php
@@ -38,6 +38,17 @@ trait BaseModelEvents
     public function onCreating()
     {
 
+        /*
+         * check whether the UUID primary key is used.
+         *
+         * if the $primaryKey value is string(single key), not an array(union key),
+         * and $incrementing is false, $keytype is string,
+         * automatically use UUID as $primaryKey if the $primaryKey is empty.
+         */
+        $keyIsEmpty = is_string($this->primaryKey) && empty(array_get($this->attributes, $this->primaryKey));
+        if ($keyIsEmpty && false === $this->incrementing && 'string' === $this->keyType)
+            $this->attributes[$this->primaryKey] = $this->uuid();
+
         // auto set user id
         if ($this->autoUserId && empty($this->user_id)) {
             $user_id = $this->getAuthUserId();
@@ -108,6 +119,20 @@ trait BaseModelEvents
 
         if ('string' === $this->keyType)
             return strlen($user_id) > 0;
+    }
+
+    /**
+     * generate a uuid string.
+     *
+     * @param  bool $use32bytes
+     * @return string the uuid string
+     */
+    protected function uuid(bool $use32bytes = false): string
+    {
+        if ($use32bytes)
+            return \Ramsey\Uuid\Uuid::uuid4()->getHex();
+
+        return \Ramsey\Uuid\Uuid::uuid4()->getNodeHex();
     }
 
 }

--- a/src/Someline/Repository/Generators/Generator.php
+++ b/src/Someline/Repository/Generators/Generator.php
@@ -97,6 +97,7 @@ abstract class Generator
     {
         return [
             'class'          => $this->getClass(),
+            'long_class'     => str_replace('/', '\\', $this->getName()),
             'namespace'      => $this->getNamespace(),
             'root_namespace' => $this->getRootNamespace()
         ];

--- a/src/Someline/Repository/Generators/Generator.php
+++ b/src/Someline/Repository/Generators/Generator.php
@@ -136,8 +136,8 @@ abstract class Generator
         if (str_contains($this->name, '\\')) {
             $name = str_replace('\\', '/', $this->name);
         }
-        if (str_contains($this->name, '/')) {
-            $name = str_replace('/', '/', $this->name);
+        if (str_contains($this->name, '//')) {
+            $name = str_replace('//', '/', $this->name);
         }
 
         return Str::studly(str_replace(' ', '/', ucwords(str_replace('/', ' ', $name))));

--- a/src/Someline/Repository/Generators/MigrationGenerator.php
+++ b/src/Someline/Repository/Generators/MigrationGenerator.php
@@ -72,6 +72,9 @@ class MigrationGenerator extends Generator
      */
     public function getMigrationName()
     {
+        $this->name = str_replace('/', '', $this->name);
+        $this->name = str_replace('\\', '', $this->name);
+
         return strtolower($this->name);
     }
 

--- a/src/Someline/Repository/Generators/Stubs/controller/controller.stub
+++ b/src/Someline/Repository/Generators/Stubs/controller/controller.stub
@@ -7,8 +7,8 @@ use Dingo\Api\Exception\StoreResourceFailedException;
 use Dingo\Api\Exception\UpdateResourceFailedException;
 use Illuminate\Http\Request;
 use Prettus\Validator\Contracts\ValidatorInterface;
-use $APPNAME$Http\Requests\$CLASS$CreateRequest;
-use $APPNAME$Http\Requests\$CLASS$UpdateRequest;
+use $APPNAME$Http\Requests\$LONG_CLASS$CreateRequest;
+use $APPNAME$Http\Requests\$LONG_CLASS$UpdateRequest;
 $REPOSITORY$
 $VALIDATOR$
 


### PR DESCRIPTION
当使用  `php artisan starter:entity MyModel` 时, 原始代码是没有问题的.
但是, 当使用
`php artisan starter:entity PreNameSpace\SecondNameSpace\AndMore\MyModel`
就会出现因为"\"(或者"/")导致的字符串转义问题.
在此予以修复.